### PR TITLE
AT-8 feat: adicionar crud tipo_parametro

### DIFF
--- a/src/config/connection.ts
+++ b/src/config/connection.ts
@@ -1,6 +1,9 @@
 import { Sequelize } from 'sequelize-typescript';
 import dotenv from 'dotenv';
 import Estacao from '../models/Estacao';
+import TipoParametro from '../models/TipoParametro';
+import EstacaoTipoParametro from '../models/EstacaoTipoParametro';
+import ValorCapturado from '../models/ValorCapturado';
 
 dotenv.config();
 
@@ -11,7 +14,7 @@ const sequelize = new Sequelize({
   host: process.env.DB_HOST, // colocar domínio
   port: parseInt(process.env.DB_PORT), // colocar porta
   dialect: 'postgres', // colocar o banco de dados utilizado
-  models: [Estacao],  // Adicionar os modelos a serem trabalhados aqui
+  models: [Estacao, TipoParametro, EstacaoTipoParametro, ValorCapturado],  // Adicionar os modelos a serem trabalhados aqui
 });
 
 export default sequelize;

--- a/src/controllers/estacaoTipoParametroController.ts
+++ b/src/controllers/estacaoTipoParametroController.ts
@@ -1,0 +1,276 @@
+import { Request, Response } from 'express'
+import EstacaoTipoParametro from '../models/EstacaoTipoParametro'
+import Estacao from '../models/Estacao'
+import TipoParametro from '../models/TipoParametro'
+
+export const estacaoTipoParametroController = {
+    save: async (req: Request, res: Response) => {
+        try {
+            const { estacao_est_pk, tipo_parametro_pk } = req.body
+            
+            // Normalizar para arrays
+            const estacoesIds = Array.isArray(estacao_est_pk) ? estacao_est_pk : [estacao_est_pk]
+            const tiposParametroIds = Array.isArray(tipo_parametro_pk) ? tipo_parametro_pk : [tipo_parametro_pk]
+            
+            // Verificar se pelo menos um dos parâmetros foi fornecido
+            if (!estacao_est_pk || !tipo_parametro_pk) {
+                return res.status(400).json({ 
+                    error: 'Parâmetros estacao_est_pk e tipo_parametro_pk são obrigatórios' 
+                })
+            }
+            
+            // Verificar se todas as estações existem
+            const estacoes = await Estacao.findAll({
+                where: { pk: estacoesIds }
+            })
+            
+            if (estacoes.length !== estacoesIds.length) {
+                return res.status(404).json({ error: 'Uma ou mais estações não encontradas' })
+            }
+            
+            // Verificar se todos os tipos de parâmetros existem
+            const tiposParametros = await TipoParametro.findAll({
+                where: { pk: tiposParametroIds }
+            })
+            
+            if (tiposParametros.length !== tiposParametroIds.length) {
+                return res.status(404).json({ error: 'Um ou mais tipos de parâmetros não encontrados' })
+            }
+            
+            // Criar todas as combinações possíveis
+            let relacoesParaCriar = []
+            for (const estId of estacoesIds) {
+                for (const tpId of tiposParametroIds) {
+                    relacoesParaCriar.push({
+                        estacao_est_pk: estId,
+                        tipo_parametro_pk: tpId
+                    })
+                }
+            }
+            
+            // Verificar se alguma relação já existe
+            const relacoesExistentes = await EstacaoTipoParametro.findAll({
+                where: {
+                    [require('sequelize').Op.or]: relacoesParaCriar.map(rel => ({
+                        estacao_est_pk: rel.estacao_est_pk,
+                        tipo_parametro_pk: rel.tipo_parametro_pk
+                    }))
+                }
+            })
+            
+            if (relacoesExistentes.length > 0) {
+                return res.status(409).json({ 
+                    error: 'Uma ou mais relações já existem', 
+                    relacoesExistentes: relacoesExistentes.map(rel => ({
+                        estacao_est_pk: rel.estacao_est_pk,
+                        tipo_parametro_pk: rel.tipo_parametro_pk
+                    }))
+                })
+            }
+            
+            // Criar todas as relações
+            const novasRelacoes = await EstacaoTipoParametro.bulkCreate(relacoesParaCriar)
+            
+            return res.status(201).json({
+                message: `${novasRelacoes.length} relação(ões) criada(s) com sucesso`,
+                relacoes: novasRelacoes
+            })
+        } catch (error) {
+            return res.status(400).json({ error: 'Erro ao criar relação estação-tipo parâmetro', detalhes: error.message })
+        }
+    },
+
+    findAll: async (req: Request, res: Response) => {
+        try {
+            const relacoes = await EstacaoTipoParametro.findAll({
+                include: [
+                    {
+                        model: Estacao,
+                        as: 'estacao'
+                    },
+                    {
+                        model: TipoParametro,
+                        as: 'tipoParametro'
+                    }
+                ]
+            })
+            
+            if(!relacoes.length){
+                return res.status(404).json({ error: 'Relações não encontradas' })
+            }
+            return res.status(200).json(relacoes)
+        } catch (error) {
+            return res.status(500).json({error: 'Erro ao buscar relações', detalhes: error.message})
+        }
+    },
+
+    findById: async (req: Request, res: Response) => {
+        try {
+            const { pk } = req.params
+            const relacao = await EstacaoTipoParametro.findByPk(pk, {
+                include: [
+                    {
+                        model: Estacao,
+                        as: 'estacao'
+                    },
+                    {
+                        model: TipoParametro,
+                        as: 'tipoParametro'
+                    }
+                ]
+            })
+            
+            if(relacao) {
+                return res.status(200).json(relacao)
+            }
+            return res.status(404).json({ error: 'Relação não encontrada' })
+        } catch (error) {
+            return res.status(500).json({error: 'Erro ao buscar relação', detalhes: error.message})
+        }
+    },
+
+    findByEstacao: async (req: Request, res: Response) => {
+        try {
+            const { estacao_pk } = req.params
+            const relacoes = await EstacaoTipoParametro.findAll({
+                where: { estacao_est_pk: estacao_pk },
+                include: [
+                    {
+                        model: TipoParametro,
+                        as: 'tipoParametro'
+                    }
+                ]
+            })
+            
+            if(!relacoes.length){
+                return res.status(404).json({ error: 'Nenhuma relação encontrada para esta estação' })
+            }
+            return res.status(200).json(relacoes)
+        } catch (error) {
+            return res.status(500).json({error: 'Erro ao buscar relações da estação', detalhes: error.message})
+        }
+    },
+
+    findByTipoParametro: async (req: Request, res: Response) => {
+        try {
+            const { tipo_parametro_pk } = req.params
+            const relacoes = await EstacaoTipoParametro.findAll({
+                where: { tipo_parametro_pk },
+                include: [
+                    {
+                        model: Estacao,
+                        as: 'estacao'
+                    }
+                ]
+            })
+            
+            if(!relacoes.length){
+                return res.status(404).json({ error: 'Nenhuma relação encontrada para este tipo de parâmetro' })
+            }
+            return res.status(200).json(relacoes)
+        } catch (error) {
+            return res.status(500).json({error: 'Erro ao buscar relações do tipo de parâmetro', detalhes: error.message})
+        }
+    },
+
+    update: async (req: Request, res: Response) => {
+        try {
+            const { pk } = req.params;
+            const { estacao_est_pk, tipo_parametro_pk } = req.body
+
+            const relacao = await EstacaoTipoParametro.findByPk(pk)
+            if(!relacao){
+                return res.status(404).json({ error: 'Relação não encontrada' })
+            }
+
+            // Verificar se a nova estação existe
+            if (estacao_est_pk) {
+                const estacao = await Estacao.findByPk(estacao_est_pk)
+                if (!estacao) {
+                    return res.status(404).json({ error: 'Estação não encontrada' })
+                }
+            }
+            
+            // Verificar se o novo tipo de parâmetro existe
+            if (tipo_parametro_pk) {
+                const tipoParametro = await TipoParametro.findByPk(tipo_parametro_pk)
+                if (!tipoParametro) {
+                    return res.status(404).json({ error: 'Tipo de parâmetro não encontrado' })
+                }
+            }
+
+            // Verificar se a nova relação já existe (excluindo a atual)
+            if (estacao_est_pk && tipo_parametro_pk) {
+                const relacaoExistente = await EstacaoTipoParametro.findOne({
+                    where: {
+                        estacao_est_pk,
+                        tipo_parametro_pk,
+                        pk: { [require('sequelize').Op.ne]: pk }
+                    }
+                })
+                
+                if (relacaoExistente) {
+                    return res.status(409).json({ error: 'Relação entre estação e tipo de parâmetro já existe' })
+                }
+            }
+
+            const atualizado = await EstacaoTipoParametro.update(req.body, { where: { pk } });
+
+            if (atualizado) {
+                const relacaoAtualizada = await EstacaoTipoParametro.findByPk(pk, {
+                    include: [
+                        {
+                            model: Estacao,
+                            as: 'estacao'
+                        },
+                        {
+                            model: TipoParametro,
+                            as: 'tipoParametro'
+                        }
+                    ]
+                });
+                return res.json(relacaoAtualizada);
+            }
+
+        } catch (error: any) {
+            return res.status(400).json({ error: 'Erro ao atualizar relação', detalhes: error.message });
+        }
+    },
+
+    delete: async (req: Request, res: Response) => {
+        try {
+            const { pk } = req.params;
+
+            const deletado = await EstacaoTipoParametro.destroy({ where: { pk } });
+
+            if (deletado) {
+                return res.status(204).send();
+            }
+
+            return res.status(404).json({ error: 'Relação não encontrada' });
+        } catch (error: any) {
+            return res.status(400).json({ error: 'Erro ao deletar relação', detalhes: error.message });
+        }
+    },
+
+    deleteByEstacaoAndTipoParametro: async (req: Request, res: Response) => {
+        try {
+            const { estacao_pk, tipo_parametro_pk } = req.params;
+
+            const deletado = await EstacaoTipoParametro.destroy({ 
+                where: { 
+                    estacao_est_pk: estacao_pk,
+                    tipo_parametro_pk: tipo_parametro_pk
+                } 
+            });
+
+            if (deletado) {
+                return res.status(204).send();
+            }
+
+            return res.status(404).json({ error: 'Relação não encontrada' });
+        } catch (error: any) {
+            return res.status(400).json({ error: 'Erro ao deletar relação', detalhes: error.message });
+        }
+    }
+}

--- a/src/controllers/tipoParametroController.ts
+++ b/src/controllers/tipoParametroController.ts
@@ -1,0 +1,75 @@
+import { Request, Response } from 'express'
+import TipoParametro from '../models/TipoParametro'
+
+export const tipoParametroController = {
+    save: async (req: Request, res: Response) => {
+        try {
+            const novoRegistro = await TipoParametro.create(req.body)
+            return res.status(201).json(novoRegistro)
+        } catch (error) {
+            return res.status(400).json({ error: 'Erro ao salvar tipo de parâmetro', detalhes: error.message })
+        }
+    },
+
+    findAll: async (req: Request, res: Response) => {
+        try {
+            const registros = await TipoParametro.findAll()
+            if(!registros.length){
+                return res.status(404).json({ error: 'Registros não encontrados' })
+            }
+            return res.status(200).json(registros)
+        } catch (error) {
+            return res.status(500).json({error: 'Erro ao buscar registros', detalhes: error.message})
+        }
+    },
+
+    findById: async (req: Request, res: Response) => {
+        try {
+            const { pk } = req.params
+            const registro = await TipoParametro.findByPk(pk)
+            if(registro) {
+                return res.status(200).json(registro)
+            }
+            return res.status(404).json({ error: 'Registro não encontrado' })
+        } catch (error) {
+            return res.status(500).json({error: 'Erro ao buscar registro', detalhes: error.message})
+        }
+    },
+
+    update: async (req: Request, res: Response) => {
+        try {
+        const { pk } = req.params;
+
+        const registro = await TipoParametro.findByPk(pk)
+        if(!registro){
+            return res.status(404).json({ error: 'Registro não encontrado' })
+        }
+
+        const atualizado = await TipoParametro.update(req.body, { where: { pk } });
+
+        if (atualizado) {
+            const registro = await TipoParametro.findByPk(pk);
+            return res.json(registro);
+        }
+
+        } catch (error: any) {
+        return res.status(400).json({ error: 'Erro ao atualizar registro', detalhes: error.message });
+        }
+    },
+
+    delete: async (req: Request, res: Response) => {
+        try {
+        const { pk } = req.params;
+
+        const deletado = await TipoParametro.destroy({ where: { pk } });
+
+        if (deletado) {
+            return res.status(204).send();
+        }
+
+        return res.status(404).json({ error: 'Registro não encontrado' });
+        } catch (error: any) {
+        return res.status(400).json({ error: 'Erro ao deletar registro', detalhes: error.message });
+        }
+    }
+}

--- a/src/controllers/valorCapturadoController.ts
+++ b/src/controllers/valorCapturadoController.ts
@@ -1,0 +1,315 @@
+import { Request, Response } from 'express'
+import ValorCapturado from '../models/ValorCapturado'
+import EstacaoTipoParametro from '../models/EstacaoTipoParametro'
+import Estacao from '../models/Estacao'
+
+export const valorCapturadoController = {
+    save: async (req: Request, res: Response) => {
+        try {
+            const { unixtime, Parametros_pk, valor, estacao_id } = req.body
+            
+            // Verificar se o parâmetro existe
+            const parametro = await EstacaoTipoParametro.findByPk(Parametros_pk)
+            if (!parametro) {
+                return res.status(404).json({ error: 'Parâmetro não encontrado' })
+            }
+            
+            // Verificar se a estação existe
+            const estacao = await Estacao.findByPk(estacao_id)
+            if (!estacao) {
+                return res.status(404).json({ error: 'Estação não encontrada' })
+            }
+            
+            // Verificar se a estação do parâmetro corresponde à estação fornecida
+            if (parametro.estacao_est_pk !== estacao_id) {
+                return res.status(400).json({ error: 'A estação do parâmetro não corresponde à estação fornecida' })
+            }
+            
+            const novoValor = await ValorCapturado.create(req.body)
+            return res.status(201).json(novoValor)
+        } catch (error) {
+            return res.status(400).json({ error: 'Erro ao salvar valor capturado', detalhes: error.message })
+        }
+    },
+
+    findAll: async (req: Request, res: Response) => {
+        try {
+            const valores = await ValorCapturado.findAll({
+                include: [
+                    {
+                        model: EstacaoTipoParametro,
+                        as: 'parametro',
+                        include: [
+                            {
+                                model: Estacao,
+                                as: 'estacao'
+                            },
+                            {
+                                model: require('../models/TipoParametro').default,
+                                as: 'tipoParametro'
+                            }
+                        ]
+                    },
+                    {
+                        model: Estacao,
+                        as: 'estacao'
+                    }
+                ],
+                order: [['unixtime', 'DESC']]
+            })
+            
+            if(!valores.length){
+                return res.status(404).json({ error: 'Valores não encontrados' })
+            }
+            return res.status(200).json(valores)
+        } catch (error) {
+            return res.status(500).json({error: 'Erro ao buscar valores', detalhes: error.message})
+        }
+    },
+
+    findById: async (req: Request, res: Response) => {
+        try {
+            const { pk } = req.params
+            const valor = await ValorCapturado.findByPk(pk, {
+                include: [
+                    {
+                        model: EstacaoTipoParametro,
+                        as: 'parametro',
+                        include: [
+                            {
+                                model: Estacao,
+                                as: 'estacao'
+                            },
+                            {
+                                model: require('../models/TipoParametro').default,
+                                as: 'tipoParametro'
+                            }
+                        ]
+                    },
+                    {
+                        model: Estacao,
+                        as: 'estacao'
+                    }
+                ]
+            })
+            
+            if(valor) {
+                return res.status(200).json(valor)
+            }
+            return res.status(404).json({ error: 'Valor não encontrado' })
+        } catch (error) {
+            return res.status(500).json({error: 'Erro ao buscar valor', detalhes: error.message})
+        }
+    },
+
+    findByParametro: async (req: Request, res: Response) => {
+        try {
+            const { parametro_pk } = req.params
+            const valores = await ValorCapturado.findAll({
+                where: { Parametros_pk: parametro_pk },
+                include: [
+                    {
+                        model: EstacaoTipoParametro,
+                        as: 'parametro',
+                        include: [
+                            {
+                                model: Estacao,
+                                as: 'estacao'
+                            },
+                            {
+                                model: require('../models/TipoParametro').default,
+                                as: 'tipoParametro'
+                            }
+                        ]
+                    },
+                    {
+                        model: Estacao,
+                        as: 'estacao'
+                    }
+                ],
+                order: [['unixtime', 'DESC']]
+            })
+            
+            if(!valores.length){
+                return res.status(404).json({ error: 'Nenhum valor encontrado para este parâmetro' })
+            }
+            return res.status(200).json(valores)
+        } catch (error) {
+            return res.status(500).json({error: 'Erro ao buscar valores do parâmetro', detalhes: error.message})
+        }
+    },
+
+    findByEstacao: async (req: Request, res: Response) => {
+        try {
+            const { estacao_id } = req.params
+            const valores = await ValorCapturado.findAll({
+                where: { estacao_id },
+                include: [
+                    {
+                        model: EstacaoTipoParametro,
+                        as: 'parametro',
+                        include: [
+                            {
+                                model: Estacao,
+                                as: 'estacao'
+                            },
+                            {
+                                model: require('../models/TipoParametro').default,
+                                as: 'tipoParametro'
+                            }
+                        ]
+                    },
+                    {
+                        model: Estacao,
+                        as: 'estacao'
+                    }
+                ],
+                order: [['unixtime', 'DESC']]
+            })
+            
+            if(!valores.length){
+                return res.status(404).json({ error: 'Nenhum valor encontrado para esta estação' })
+            }
+            return res.status(200).json(valores)
+        } catch (error) {
+            return res.status(500).json({error: 'Erro ao buscar valores da estação', detalhes: error.message})
+        }
+    },
+
+    findByDateRange: async (req: Request, res: Response) => {
+        try {
+            const { start_date, end_date, estacao_id, parametro_pk } = req.query
+            
+            let whereClause: any = {}
+            
+            if (start_date && end_date) {
+                whereClause.unixtime = {
+                    [require('sequelize').Op.between]: [new Date(start_date as string), new Date(end_date as string)]
+                }
+            }
+            
+            if (estacao_id) {
+                whereClause.estacao_id = estacao_id
+            }
+            
+            if (parametro_pk) {
+                whereClause.Parametros_pk = parametro_pk
+            }
+            
+            const valores = await ValorCapturado.findAll({
+                where: whereClause,
+                include: [
+                    {
+                        model: EstacaoTipoParametro,
+                        as: 'parametro',
+                        include: [
+                            {
+                                model: Estacao,
+                                as: 'estacao'
+                            },
+                            {
+                                model: require('../models/TipoParametro').default,
+                                as: 'tipoParametro'
+                            }
+                        ]
+                    },
+                    {
+                        model: Estacao,
+                        as: 'estacao'
+                    }
+                ],
+                order: [['unixtime', 'DESC']]
+            })
+            
+            if(!valores.length){
+                return res.status(404).json({ error: 'Nenhum valor encontrado para os filtros aplicados' })
+            }
+            return res.status(200).json(valores)
+        } catch (error) {
+            return res.status(500).json({error: 'Erro ao buscar valores por período', detalhes: error.message})
+        }
+    },
+
+    update: async (req: Request, res: Response) => {
+        try {
+            const { pk } = req.params;
+            const { unixtime, Parametros_pk, valor, estacao_id } = req.body
+
+            const valorCapturado = await ValorCapturado.findByPk(pk)
+            if(!valorCapturado){
+                return res.status(404).json({ error: 'Valor não encontrado' })
+            }
+
+            // Verificar se o parâmetro existe
+            if (Parametros_pk) {
+                const parametro = await EstacaoTipoParametro.findByPk(Parametros_pk)
+                if (!parametro) {
+                    return res.status(404).json({ error: 'Parâmetro não encontrado' })
+                }
+            }
+            
+            // Verificar se a estação existe
+            if (estacao_id) {
+                const estacao = await Estacao.findByPk(estacao_id)
+                if (!estacao) {
+                    return res.status(404).json({ error: 'Estação não encontrada' })
+                }
+            }
+
+            // Verificar consistência entre parâmetro e estação
+            if (Parametros_pk && estacao_id) {
+                const parametro = await EstacaoTipoParametro.findByPk(Parametros_pk)
+                if (parametro && parametro.estacao_est_pk !== estacao_id) {
+                    return res.status(400).json({ error: 'A estação do parâmetro não corresponde à estação fornecida' })
+                }
+            }
+
+            const atualizado = await ValorCapturado.update(req.body, { where: { pk } });
+
+            if (atualizado) {
+                const valorAtualizado = await ValorCapturado.findByPk(pk, {
+                    include: [
+                        {
+                            model: EstacaoTipoParametro,
+                            as: 'parametro',
+                            include: [
+                                {
+                                    model: Estacao,
+                                    as: 'estacao'
+                                },
+                                {
+                                    model: require('../models/TipoParametro').default,
+                                    as: 'tipoParametro'
+                                }
+                            ]
+                        },
+                        {
+                            model: Estacao,
+                            as: 'estacao'
+                        }
+                    ]
+                });
+                return res.json(valorAtualizado);
+            }
+
+        } catch (error: any) {
+            return res.status(400).json({ error: 'Erro ao atualizar valor', detalhes: error.message });
+        }
+    },
+
+    delete: async (req: Request, res: Response) => {
+        try {
+            const { pk } = req.params;
+
+            const deletado = await ValorCapturado.destroy({ where: { pk } });
+
+            if (deletado) {
+                return res.status(204).send();
+            }
+
+            return res.status(404).json({ error: 'Valor não encontrado' });
+        } catch (error: any) {
+            return res.status(400).json({ error: 'Erro ao deletar valor', detalhes: error.message });
+        }
+    }
+}

--- a/src/interfaces/swagger/estacaoTipoParametroSwagger.ts
+++ b/src/interfaces/swagger/estacaoTipoParametroSwagger.ts
@@ -1,0 +1,406 @@
+export const estacaoTipoParametroSwagger = {
+  "/estacao-tipo-parametro": {
+    post: {
+      summary: "Criar uma ou mais relações estação-tipo parâmetro",
+      description: "Aceita estacao_est_pk e tipo_parametro_pk como valores únicos ou arrays. Cria todas as combinações possíveis entre os valores fornecidos.",
+      requestBody: {
+        description: "Dados da(s) relação(ões) estação-tipo parâmetro para criar",
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              properties: {
+                estacao_est_pk: { 
+                  oneOf: [
+                    { type: "integer", description: "ID da estação" },
+                    { 
+                      type: "array", 
+                      items: { type: "integer" },
+                      description: "Array de IDs das estações" 
+                    }
+                  ]
+                },
+                tipo_parametro_pk: { 
+                  oneOf: [
+                    { type: "integer", description: "ID do tipo de parâmetro" },
+                    { 
+                      type: "array", 
+                      items: { type: "integer" },
+                      description: "Array de IDs dos tipos de parâmetros" 
+                    }
+                  ]
+                },
+              },
+              required: ["estacao_est_pk", "tipo_parametro_pk"],
+            },
+          },
+        },
+      },
+      responses: {
+        "201": {
+          description: "Relação(ões) criada(s) com sucesso",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  message: { type: "string", description: "Mensagem de sucesso" },
+                  relacoes: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        pk: { type: "integer" },
+                        estacao_est_pk: { type: "integer" },
+                        tipo_parametro_pk: { type: "integer" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "400": {
+          description: "Erro de validação",
+        },
+        "404": {
+          description: "Estação ou tipo de parâmetro não encontrado",
+        },
+        "409": {
+          description: "Uma ou mais relações já existem",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  error: { type: "string" },
+                  relacoesExistentes: {
+                    type: "array",
+                    items: {
+                      type: "object",
+                      properties: {
+                        estacao_est_pk: { type: "integer" },
+                        tipo_parametro_pk: { type: "integer" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    get: {
+      summary: "Listar todas as relações estação-tipo parâmetro",
+      responses: {
+        "200": {
+          description: "Lista de relações estação-tipo parâmetro",
+          content: {
+            "application/json": {
+              schema: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    pk: { type: "integer" },
+                    estacao_est_pk: { type: "integer" },
+                    tipo_parametro_pk: { type: "integer" },
+                    estacao: {
+                      type: "object",
+                      properties: {
+                        pk: { type: "integer" },
+                        uuid: { type: "string" },
+                        nome: { type: "string" },
+                        descricao: { type: "string" },
+                        status: { type: "boolean" },
+                      },
+                    },
+                    tipoParametro: {
+                      type: "object",
+                      properties: {
+                        pk: { type: "integer" },
+                        nome: { type: "string" },
+                        tipo: { type: "string" },
+                        unidade: { type: "string" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "404": {
+          description: "Nenhuma relação encontrada",
+        },
+      },
+    },
+  },
+  "/estacao-tipo-parametro/{pk}": {
+    get: {
+      summary: "Obter uma relação estação-tipo parâmetro pelo ID",
+      parameters: [
+        {
+          in: "path",
+          name: "pk",
+          required: true,
+          schema: { type: "integer" },
+          description: "ID da relação",
+        },
+      ],
+      responses: {
+        "200": {
+          description: "Relação encontrada",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  pk: { type: "integer" },
+                  estacao_est_pk: { type: "integer" },
+                  tipo_parametro_pk: { type: "integer" },
+                  estacao: {
+                    type: "object",
+                    properties: {
+                      pk: { type: "integer" },
+                      uuid: { type: "string" },
+                      nome: { type: "string" },
+                      descricao: { type: "string" },
+                      status: { type: "boolean" },
+                    },
+                  },
+                  tipoParametro: {
+                    type: "object",
+                    properties: {
+                      pk: { type: "integer" },
+                      nome: { type: "string" },
+                      tipo: { type: "string" },
+                      unidade: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "404": {
+          description: "Relação não encontrada",
+        },
+      },
+    },
+    put: {
+      summary: "Atualizar uma relação estação-tipo parâmetro",
+      parameters: [
+        {
+          in: "path",
+          name: "pk",
+          required: true,
+          schema: { type: "integer" },
+          description: "ID da relação",
+        },
+      ],
+      requestBody: {
+        description: "Dados da relação para atualizar",
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              properties: {
+                estacao_est_pk: { type: "integer", description: "ID da estação" },
+                tipo_parametro_pk: { type: "integer", description: "ID do tipo de parâmetro" },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        "200": {
+          description: "Relação atualizada com sucesso",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  pk: { type: "integer" },
+                  estacao_est_pk: { type: "integer" },
+                  tipo_parametro_pk: { type: "integer" },
+                  estacao: {
+                    type: "object",
+                    properties: {
+                      pk: { type: "integer" },
+                      uuid: { type: "string" },
+                      nome: { type: "string" },
+                      descricao: { type: "string" },
+                      status: { type: "boolean" },
+                    },
+                  },
+                  tipoParametro: {
+                    type: "object",
+                    properties: {
+                      pk: { type: "integer" },
+                      nome: { type: "string" },
+                      tipo: { type: "string" },
+                      unidade: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "404": {
+          description: "Relação, estação ou tipo de parâmetro não encontrado",
+        },
+        "409": {
+          description: "Nova relação já existe",
+        },
+      },
+    },
+    delete: {
+      summary: "Excluir uma relação estação-tipo parâmetro",
+      parameters: [
+        {
+          in: "path",
+          name: "pk",
+          required: true,
+          schema: { type: "integer" },
+          description: "ID da relação",
+        },
+      ],
+      responses: {
+        "204": {
+          description: "Relação deletada com sucesso",
+        },
+        "404": {
+          description: "Relação não encontrada",
+        },
+      },
+    },
+  },
+  "/estacao-tipo-parametro/estacao/{estacao_pk}": {
+    get: {
+      summary: "Listar todas as relações de uma estação específica",
+      parameters: [
+        {
+          in: "path",
+          name: "estacao_pk",
+          required: true,
+          schema: { type: "integer" },
+          description: "ID da estação",
+        },
+      ],
+      responses: {
+        "200": {
+          description: "Lista de relações da estação",
+          content: {
+            "application/json": {
+              schema: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    pk: { type: "integer" },
+                    estacao_est_pk: { type: "integer" },
+                    tipo_parametro_pk: { type: "integer" },
+                    tipoParametro: {
+                      type: "object",
+                      properties: {
+                        pk: { type: "integer" },
+                        nome: { type: "string" },
+                        tipo: { type: "string" },
+                        unidade: { type: "string" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "404": {
+          description: "Nenhuma relação encontrada para esta estação",
+        },
+      },
+    },
+  },
+  "/estacao-tipo-parametro/tipo-parametro/{tipo_parametro_pk}": {
+    get: {
+      summary: "Listar todas as relações de um tipo de parâmetro específico",
+      parameters: [
+        {
+          in: "path",
+          name: "tipo_parametro_pk",
+          required: true,
+          schema: { type: "integer" },
+          description: "ID do tipo de parâmetro",
+        },
+      ],
+      responses: {
+        "200": {
+          description: "Lista de relações do tipo de parâmetro",
+          content: {
+            "application/json": {
+              schema: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    pk: { type: "integer" },
+                    estacao_est_pk: { type: "integer" },
+                    tipo_parametro_pk: { type: "integer" },
+                    estacao: {
+                      type: "object",
+                      properties: {
+                        pk: { type: "integer" },
+                        uuid: { type: "string" },
+                        nome: { type: "string" },
+                        descricao: { type: "string" },
+                        status: { type: "boolean" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "404": {
+          description: "Nenhuma relação encontrada para este tipo de parâmetro",
+        },
+      },
+    },
+  },
+  "/estacao-tipo-parametro/estacao/{estacao_pk}/tipo-parametro/{tipo_parametro_pk}": {
+    delete: {
+      summary: "Excluir uma relação específica entre estação e tipo de parâmetro",
+      parameters: [
+        {
+          in: "path",
+          name: "estacao_pk",
+          required: true,
+          schema: { type: "integer" },
+          description: "ID da estação",
+        },
+        {
+          in: "path",
+          name: "tipo_parametro_pk",
+          required: true,
+          schema: { type: "integer" },
+          description: "ID do tipo de parâmetro",
+        },
+      ],
+      responses: {
+        "204": {
+          description: "Relação deletada com sucesso",
+        },
+        "404": {
+          description: "Relação não encontrada",
+        },
+      },
+    },
+  },
+};

--- a/src/interfaces/swagger/swagger.ts
+++ b/src/interfaces/swagger/swagger.ts
@@ -1,6 +1,9 @@
 import { Express } from "express";
 import swaggerUi from "swagger-ui-express";
 import { estacaoSwagger } from './estacaoSwagger'
+import { tipoParametroSwagger } from './tipoParametroSwagger'
+import { estacaoTipoParametroSwagger } from './estacaoTipoParametroSwagger'
+import { valorCapturadoSwagger } from './valorCapturadoSwagger'
 
 export function registerSwagger(app: Express): void {
   const openapi = {
@@ -12,7 +15,10 @@ export function registerSwagger(app: Express): void {
     },
     servers: [{ url: "/" }],
     paths: {
-      ...estacaoSwagger
+      ...estacaoSwagger,
+      ...tipoParametroSwagger,
+      ...estacaoTipoParametroSwagger,
+      ...valorCapturadoSwagger
     },
   } as const
 

--- a/src/interfaces/swagger/tipoParametroSwagger.ts
+++ b/src/interfaces/swagger/tipoParametroSwagger.ts
@@ -1,0 +1,205 @@
+export const tipoParametroSwagger = {
+  "/tipo-parametro": {
+    post: {
+      summary: "Criar um novo tipo de parâmetro",
+      requestBody: {
+        description: "Dados do tipo de parâmetro para criar",
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              properties: {
+                json_id: { type: "string", nullable: true },
+                nome: { type: "string", nullable: true },
+                tipo: { type: "string", nullable: true },
+                offset: { type: "number", nullable: true },
+                fator: { type: "number", nullable: true },
+                polinomio: { type: "string", nullable: true },
+                unidade: { type: "string", nullable: true },
+                alarme: { type: "number", nullable: true },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        "201": {
+          description: "Tipo de parâmetro criado com sucesso",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  pk: { type: "integer" },
+                  json_id: { type: "string", nullable: true },
+                  nome: { type: "string", nullable: true },
+                  tipo: { type: "string", nullable: true },
+                  offset: { type: "number", nullable: true },
+                  fator: { type: "number", nullable: true },
+                  polinomio: { type: "string", nullable: true },
+                  unidade: { type: "string", nullable: true },
+                  alarme: { type: "number", nullable: true },
+                },
+              },
+            },
+          },
+        },
+        "400": {
+          description: "Erro de validação",
+        },
+      },
+    },
+    get: {
+      summary: "Listar todos os tipos de parâmetros",
+      responses: {
+        "200": {
+          description: "Lista de tipos de parâmetros",
+          content: {
+            "application/json": {
+              schema: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    pk: { type: "integer" },
+                    json_id: { type: "string", nullable: true },
+                    nome: { type: "string", nullable: true },
+                    tipo: { type: "string", nullable: true },
+                    offset: { type: "number", nullable: true },
+                    fator: { type: "number", nullable: true },
+                    polinomio: { type: "string", nullable: true },
+                    unidade: { type: "string", nullable: true },
+                    alarme: { type: "number", nullable: true },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "404": {
+          description: "Nenhum tipo de parâmetro encontrado",
+        },
+      },
+    },
+  },
+  "/tipo-parametro/{pk}": {
+    get: {
+      summary: "Obter um tipo de parâmetro pelo ID",
+      parameters: [
+        {
+          in: "path",
+          name: "pk",
+          required: true,
+          schema: { type: "integer" },
+          description: "ID do tipo de parâmetro",
+        },
+      ],
+      responses: {
+        "200": {
+          description: "Tipo de parâmetro encontrado",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  pk: { type: "integer" },
+                  json_id: { type: "string", nullable: true },
+                  nome: { type: "string", nullable: true },
+                  tipo: { type: "string", nullable: true },
+                  offset: { type: "number", nullable: true },
+                  fator: { type: "number", nullable: true },
+                  polinomio: { type: "string", nullable: true },
+                  unidade: { type: "string", nullable: true },
+                  alarme: { type: "number", nullable: true },
+                },
+              },
+            },
+          },
+        },
+        "404": {
+          description: "Tipo de parâmetro não encontrado",
+        },
+      },
+    },
+    put: {
+      summary: "Atualizar um tipo de parâmetro",
+      parameters: [
+        {
+          in: "path",
+          name: "pk",
+          required: true,
+          schema: { type: "integer" },
+          description: "ID do tipo de parâmetro",
+        },
+      ],
+      requestBody: {
+        description: "Dados do tipo de parâmetro para atualizar",
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              properties: {
+                json_id: { type: "string", nullable: true },
+                nome: { type: "string", nullable: true },
+                tipo: { type: "string", nullable: true },
+                offset: { type: "number", nullable: true },
+                fator: { type: "number", nullable: true },
+                polinomio: { type: "string", nullable: true },
+                unidade: { type: "string", nullable: true },
+                alarme: { type: "number", nullable: true },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        "200": {
+          description: "Tipo de parâmetro atualizado com sucesso",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  pk: { type: "integer" },
+                  json_id: { type: "string", nullable: true },
+                  nome: { type: "string", nullable: true },
+                  tipo: { type: "string", nullable: true },
+                  offset: { type: "number", nullable: true },
+                  fator: { type: "number", nullable: true },
+                  polinomio: { type: "string", nullable: true },
+                  unidade: { type: "string", nullable: true },
+                  alarme: { type: "number", nullable: true },
+                },
+              },
+            },
+          },
+        },
+        "404": {
+          description: "Tipo de parâmetro não encontrado",
+        },
+      },
+    },
+    delete: {
+      summary: "Excluir um tipo de parâmetro",
+      parameters: [
+        {
+          in: "path",
+          name: "pk",
+          required: true,
+          schema: { type: "integer" },
+          description: "ID do tipo de parâmetro",
+        },
+      ],
+      responses: {
+        "204": {
+          description: "Tipo de parâmetro deletado com sucesso",
+        },
+        "404": {
+          description: "Tipo de parâmetro não encontrado",
+        },
+      },
+    },
+  },
+};

--- a/src/interfaces/swagger/valorCapturadoSwagger.ts
+++ b/src/interfaces/swagger/valorCapturadoSwagger.ts
@@ -1,0 +1,521 @@
+export const valorCapturadoSwagger = {
+  "/valor-capturado": {
+    post: {
+      summary: "Criar um novo valor capturado",
+      requestBody: {
+        description: "Dados do valor capturado para criar",
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              properties: {
+                unixtime: { type: "string", format: "date-time", description: "Data e hora da captura" },
+                Parametros_pk: { type: "integer", description: "ID do parâmetro (EstacaoTipoParametro)" },
+                valor: { type: "number", description: "Valor capturado" },
+                estacao_id: { type: "integer", description: "ID da estação" },
+              },
+              required: ["unixtime", "Parametros_pk", "valor", "estacao_id"],
+            },
+          },
+        },
+      },
+      responses: {
+        "201": {
+          description: "Valor capturado criado com sucesso",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  pk: { type: "integer" },
+                  unixtime: { type: "string", format: "date-time" },
+                  Parametros_pk: { type: "integer" },
+                  valor: { type: "number" },
+                  estacao_id: { type: "integer" },
+                },
+              },
+            },
+          },
+        },
+        "400": {
+          description: "Erro de validação",
+        },
+        "404": {
+          description: "Parâmetro ou estação não encontrado",
+        },
+      },
+    },
+    get: {
+      summary: "Listar todos os valores capturados",
+      responses: {
+        "200": {
+          description: "Lista de valores capturados",
+          content: {
+            "application/json": {
+              schema: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    pk: { type: "integer" },
+                    unixtime: { type: "string", format: "date-time" },
+                    Parametros_pk: { type: "integer" },
+                    valor: { type: "number" },
+                    estacao_id: { type: "integer" },
+                    parametro: {
+                      type: "object",
+                      properties: {
+                        pk: { type: "integer" },
+                        estacao_est_pk: { type: "integer" },
+                        tipo_parametro_pk: { type: "integer" },
+                        estacao: {
+                          type: "object",
+                          properties: {
+                            pk: { type: "integer" },
+                            uuid: { type: "string" },
+                            nome: { type: "string" },
+                          },
+                        },
+                        tipoParametro: {
+                          type: "object",
+                          properties: {
+                            pk: { type: "integer" },
+                            nome: { type: "string" },
+                            tipo: { type: "string" },
+                            unidade: { type: "string" },
+                          },
+                        },
+                      },
+                    },
+                    estacao: {
+                      type: "object",
+                      properties: {
+                        pk: { type: "integer" },
+                        uuid: { type: "string" },
+                        nome: { type: "string" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "404": {
+          description: "Nenhum valor encontrado",
+        },
+      },
+    },
+  },
+  "/valor-capturado/{pk}": {
+    get: {
+      summary: "Obter um valor capturado pelo ID",
+      parameters: [
+        {
+          in: "path",
+          name: "pk",
+          required: true,
+          schema: { type: "integer" },
+          description: "ID do valor capturado",
+        },
+      ],
+      responses: {
+        "200": {
+          description: "Valor capturado encontrado",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  pk: { type: "integer" },
+                  unixtime: { type: "string", format: "date-time" },
+                  Parametros_pk: { type: "integer" },
+                  valor: { type: "number" },
+                  estacao_id: { type: "integer" },
+                  parametro: {
+                    type: "object",
+                    properties: {
+                      pk: { type: "integer" },
+                      estacao_est_pk: { type: "integer" },
+                      tipo_parametro_pk: { type: "integer" },
+                      estacao: {
+                        type: "object",
+                        properties: {
+                          pk: { type: "integer" },
+                          uuid: { type: "string" },
+                          nome: { type: "string" },
+                        },
+                      },
+                      tipoParametro: {
+                        type: "object",
+                        properties: {
+                          pk: { type: "integer" },
+                          nome: { type: "string" },
+                          tipo: { type: "string" },
+                          unidade: { type: "string" },
+                        },
+                      },
+                    },
+                  },
+                  estacao: {
+                    type: "object",
+                    properties: {
+                      pk: { type: "integer" },
+                      uuid: { type: "string" },
+                      nome: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "404": {
+          description: "Valor capturado não encontrado",
+        },
+      },
+    },
+    put: {
+      summary: "Atualizar um valor capturado",
+      parameters: [
+        {
+          in: "path",
+          name: "pk",
+          required: true,
+          schema: { type: "integer" },
+          description: "ID do valor capturado",
+        },
+      ],
+      requestBody: {
+        description: "Dados do valor para atualizar",
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              properties: {
+                unixtime: { type: "string", format: "date-time" },
+                Parametros_pk: { type: "integer" },
+                valor: { type: "number" },
+                estacao_id: { type: "integer" },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        "200": {
+          description: "Valor capturado atualizado com sucesso",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  pk: { type: "integer" },
+                  unixtime: { type: "string", format: "date-time" },
+                  Parametros_pk: { type: "integer" },
+                  valor: { type: "number" },
+                  estacao_id: { type: "integer" },
+                  parametro: {
+                    type: "object",
+                    properties: {
+                      pk: { type: "integer" },
+                      estacao_est_pk: { type: "integer" },
+                      tipo_parametro_pk: { type: "integer" },
+                      estacao: {
+                        type: "object",
+                        properties: {
+                          pk: { type: "integer" },
+                          uuid: { type: "string" },
+                          nome: { type: "string" },
+                        },
+                      },
+                      tipoParametro: {
+                        type: "object",
+                        properties: {
+                          pk: { type: "integer" },
+                          nome: { type: "string" },
+                          tipo: { type: "string" },
+                          unidade: { type: "string" },
+                        },
+                      },
+                    },
+                  },
+                  estacao: {
+                    type: "object",
+                    properties: {
+                      pk: { type: "integer" },
+                      uuid: { type: "string" },
+                      nome: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "404": {
+          description: "Valor capturado, parâmetro ou estação não encontrado",
+        },
+      },
+    },
+    delete: {
+      summary: "Excluir um valor capturado",
+      parameters: [
+        {
+          in: "path",
+          name: "pk",
+          required: true,
+          schema: { type: "integer" },
+          description: "ID do valor capturado",
+        },
+      ],
+      responses: {
+        "204": {
+          description: "Valor capturado deletado com sucesso",
+        },
+        "404": {
+          description: "Valor capturado não encontrado",
+        },
+      },
+    },
+  },
+  "/valor-capturado/parametro/{parametro_pk}": {
+    get: {
+      summary: "Listar todos os valores capturados de um parâmetro específico",
+      parameters: [
+        {
+          in: "path",
+          name: "parametro_pk",
+          required: true,
+          schema: { type: "integer" },
+          description: "ID do parâmetro",
+        },
+      ],
+      responses: {
+        "200": {
+          description: "Lista de valores do parâmetro",
+          content: {
+            "application/json": {
+              schema: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    pk: { type: "integer" },
+                    unixtime: { type: "string", format: "date-time" },
+                    Parametros_pk: { type: "integer" },
+                    valor: { type: "number" },
+                    estacao_id: { type: "integer" },
+                    parametro: {
+                      type: "object",
+                      properties: {
+                        pk: { type: "integer" },
+                        estacao_est_pk: { type: "integer" },
+                        tipo_parametro_pk: { type: "integer" },
+                        estacao: {
+                          type: "object",
+                          properties: {
+                            pk: { type: "integer" },
+                            uuid: { type: "string" },
+                            nome: { type: "string" },
+                          },
+                        },
+                        tipoParametro: {
+                          type: "object",
+                          properties: {
+                            pk: { type: "integer" },
+                            nome: { type: "string" },
+                            tipo: { type: "string" },
+                            unidade: { type: "string" },
+                          },
+                        },
+                      },
+                    },
+                    estacao: {
+                      type: "object",
+                      properties: {
+                        pk: { type: "integer" },
+                        uuid: { type: "string" },
+                        nome: { type: "string" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "404": {
+          description: "Nenhum valor encontrado para este parâmetro",
+        },
+      },
+    },
+  },
+  "/valor-capturado/estacao/{estacao_id}": {
+    get: {
+      summary: "Listar todos os valores capturados de uma estação específica",
+      parameters: [
+        {
+          in: "path",
+          name: "estacao_id",
+          required: true,
+          schema: { type: "integer" },
+          description: "ID da estação",
+        },
+      ],
+      responses: {
+        "200": {
+          description: "Lista de valores da estação",
+          content: {
+            "application/json": {
+              schema: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    pk: { type: "integer" },
+                    unixtime: { type: "string", format: "date-time" },
+                    Parametros_pk: { type: "integer" },
+                    valor: { type: "number" },
+                    estacao_id: { type: "integer" },
+                    parametro: {
+                      type: "object",
+                      properties: {
+                        pk: { type: "integer" },
+                        estacao_est_pk: { type: "integer" },
+                        tipo_parametro_pk: { type: "integer" },
+                        estacao: {
+                          type: "object",
+                          properties: {
+                            pk: { type: "integer" },
+                            uuid: { type: "string" },
+                            nome: { type: "string" },
+                          },
+                        },
+                        tipoParametro: {
+                          type: "object",
+                          properties: {
+                            pk: { type: "integer" },
+                            nome: { type: "string" },
+                            tipo: { type: "string" },
+                            unidade: { type: "string" },
+                          },
+                        },
+                      },
+                    },
+                    estacao: {
+                      type: "object",
+                      properties: {
+                        pk: { type: "integer" },
+                        uuid: { type: "string" },
+                        nome: { type: "string" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "404": {
+          description: "Nenhum valor encontrado para esta estação",
+        },
+      },
+    },
+  },
+  "/valor-capturado/filtros/periodo": {
+    get: {
+      summary: "Listar valores capturados com filtros de período e outros critérios",
+      parameters: [
+        {
+          in: "query",
+          name: "start_date",
+          required: false,
+          schema: { type: "string", format: "date-time" },
+          description: "Data de início do período",
+        },
+        {
+          in: "query",
+          name: "end_date",
+          required: false,
+          schema: { type: "string", format: "date-time" },
+          description: "Data de fim do período",
+        },
+        {
+          in: "query",
+          name: "estacao_id",
+          required: false,
+          schema: { type: "integer" },
+          description: "ID da estação para filtrar",
+        },
+        {
+          in: "query",
+          name: "parametro_pk",
+          required: false,
+          schema: { type: "integer" },
+          description: "ID do parâmetro para filtrar",
+        },
+      ],
+      responses: {
+        "200": {
+          description: "Lista de valores filtrados",
+          content: {
+            "application/json": {
+              schema: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    pk: { type: "integer" },
+                    unixtime: { type: "string", format: "date-time" },
+                    Parametros_pk: { type: "integer" },
+                    valor: { type: "number" },
+                    estacao_id: { type: "integer" },
+                    parametro: {
+                      type: "object",
+                      properties: {
+                        pk: { type: "integer" },
+                        estacao_est_pk: { type: "integer" },
+                        tipo_parametro_pk: { type: "integer" },
+                        estacao: {
+                          type: "object",
+                          properties: {
+                            pk: { type: "integer" },
+                            uuid: { type: "string" },
+                            nome: { type: "string" },
+                          },
+                        },
+                        tipoParametro: {
+                          type: "object",
+                          properties: {
+                            pk: { type: "integer" },
+                            nome: { type: "string" },
+                            tipo: { type: "string" },
+                            unidade: { type: "string" },
+                          },
+                        },
+                      },
+                    },
+                    estacao: {
+                      type: "object",
+                      properties: {
+                        pk: { type: "integer" },
+                        uuid: { type: "string" },
+                        nome: { type: "string" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "404": {
+          description: "Nenhum valor encontrado para os filtros aplicados",
+        },
+      },
+    },
+  },
+};

--- a/src/models/Estacao.ts
+++ b/src/models/Estacao.ts
@@ -1,4 +1,6 @@
-import { Table, Column, Model, DataType } from 'sequelize-typescript'
+import { Table, Column, Model, DataType, BelongsToMany } from 'sequelize-typescript';
+import TipoParametro from './TipoParametro';
+import EstacaoTipoParametro from './EstacaoTipoParametro';
 
 @Table({
     tableName: 'estacoes',
@@ -11,53 +13,56 @@ export default class Estacao extends Model {
         primaryKey: true,
         autoIncrement: true
     })
-    pk!: number
+    pk!: number;
 
     @Column({
         type: DataType.STRING(255),
         allowNull: false
     })
-    uuid!: string
+    uuid!: string;
 
     @Column({
         type: DataType.STRING(255),
         allowNull: false
     })
-    nome!: string
+    nome!: string;
 
     @Column({
-        type: DataType.TEXT,  
+        type: DataType.TEXT,
         allowNull: false
     })
-    descricao!: string
+    descricao!: string;
 
     @Column({
         type: DataType.STRING(255),
-        allowNull: true 
+        allowNull: true
     })
-    link!: string | null
+    link!: string | null;
 
     @Column({
         type: DataType.BOOLEAN,
         allowNull: false
     })
-    status!: boolean
+    status!: boolean;
 
     @Column({
         type: DataType.STRING(255),
-        allowNull: true  
+        allowNull: true
     })
-    lat!: string | null
+    lat!: string | null;
 
     @Column({
         type: DataType.STRING(255),
-        allowNull: true  
+        allowNull: true
     })
-    long!: string | null
+    long!: string | null;
 
     @Column({
         type: DataType.STRING(255),
-        allowNull: true  
+        allowNull: true
     })
-    endereco!: string | null
+    endereco!: string | null;
+
+    @BelongsToMany(() => TipoParametro, () => EstacaoTipoParametro, 'estacao_est_pk', 'tipo_parametro_pk')
+    tipoParametros!: TipoParametro[];
 }

--- a/src/models/EstacaoTipoParametro.ts
+++ b/src/models/EstacaoTipoParametro.ts
@@ -1,0 +1,43 @@
+import { Table, Column, Model, DataType, BelongsTo, ForeignKey, HasMany } from 'sequelize-typescript';
+import Estacao from './Estacao';
+import TipoParametro from './TipoParametro';
+import ValorCapturado from './ValorCapturado';
+
+@Table({
+    tableName: 'parametro',
+    timestamps: false
+})
+export default class EstacaoTipoParametro extends Model {
+
+    @Column({
+        type: DataType.INTEGER,
+        primaryKey: true,
+        autoIncrement: true
+    })
+    pk!: number;
+
+    @ForeignKey(() => Estacao)
+    @Column({
+        type: DataType.INTEGER,
+        allowNull: false,
+        field: 'estacao_est_pk'
+    })
+    estacao_est_pk!: number;
+
+    @ForeignKey(() => TipoParametro)
+    @Column({
+        type: DataType.INTEGER,
+        allowNull: false,
+        field: 'tipo_parametro_pk'
+    })
+    tipo_parametro_pk!: number;
+
+    @BelongsTo(() => Estacao)
+    estacao!: Estacao;
+
+    @BelongsTo(() => TipoParametro)
+    tipoParametro!: TipoParametro;
+
+    @HasMany(() => ValorCapturado, 'Parametros_pk')
+    valoresCapturados!: ValorCapturado[];
+}

--- a/src/models/TipoParametro.ts
+++ b/src/models/TipoParametro.ts
@@ -1,0 +1,68 @@
+import { Table, Column, Model, DataType, BelongsToMany } from 'sequelize-typescript';
+import Estacao from './Estacao';
+import EstacaoTipoParametro from './EstacaoTipoParametro';
+
+@Table({
+    tableName: 'tipo_parametro',
+    timestamps: false
+})
+export default class TipoParametro extends Model {
+
+    @Column({
+        type: DataType.INTEGER,
+        primaryKey: true,
+        autoIncrement: true
+    })
+    pk!: number;
+
+    @Column({
+        type: DataType.STRING(255),
+        allowNull: true
+    })
+    json_id!: string | null;
+
+    @Column({
+        type: DataType.STRING(255),
+        allowNull: true
+    })
+    nome!: string | null;
+
+    @Column({
+        type: DataType.STRING(255),
+        allowNull: true
+    })
+    tipo!: string | null;
+
+    @Column({
+        type: DataType.DECIMAL(8, 4),
+        allowNull: true
+    })
+    offset!: number | null;
+
+    @Column({
+        type: DataType.DECIMAL(8, 4),
+        allowNull: true
+    })
+    fator!: number | null;
+
+    @Column({
+        type: DataType.STRING(255),
+        allowNull: true
+    })
+    polinomio!: string | null;
+
+    @Column({
+        type: DataType.STRING(20),
+        allowNull: true
+    })
+    unidade!: string | null;
+
+    @Column({
+        type: DataType.FLOAT,
+        allowNull: true
+    })
+    alarme!: number | null;
+
+    @BelongsToMany(() => Estacao, () => EstacaoTipoParametro, 'tipo_parametro_pk', 'estacao_est_pk')
+    estacoes!: Estacao[];
+}

--- a/src/models/ValorCapturado.ts
+++ b/src/models/ValorCapturado.ts
@@ -1,0 +1,52 @@
+import { Table, Column, Model, DataType, BelongsTo, ForeignKey } from 'sequelize-typescript';
+import EstacaoTipoParametro from './EstacaoTipoParametro';
+import Estacao from './Estacao';
+
+@Table({
+    tableName: 'valor_capturado',
+    timestamps: false
+})
+export default class ValorCapturado extends Model {
+
+    @Column({
+        type: DataType.INTEGER,
+        primaryKey: true,
+        autoIncrement: true
+    })
+    pk!: number;
+
+    @Column({
+        type: DataType.DATE,
+        allowNull: false,
+        field: 'unixtime'
+    })
+    unixtime!: Date;
+
+    @ForeignKey(() => EstacaoTipoParametro)
+    @Column({
+        type: DataType.INTEGER,
+        allowNull: false,
+        field: 'Parametros_pk'
+    })
+    Parametros_pk!: number;
+
+    @Column({
+        type: DataType.DECIMAL(8, 4),
+        allowNull: false
+    })
+    valor!: number;
+
+    @ForeignKey(() => Estacao)
+    @Column({
+        type: DataType.INTEGER,
+        allowNull: false,
+        field: 'estacao_id'
+    })
+    estacao_id!: number;
+
+    @BelongsTo(() => EstacaoTipoParametro)
+    parametro!: EstacaoTipoParametro;
+
+    @BelongsTo(() => Estacao)
+    estacao!: Estacao;
+}

--- a/src/routes/estacaoTipoParametroRoutes.ts
+++ b/src/routes/estacaoTipoParametroRoutes.ts
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+import { estacaoTipoParametroController } from '../controllers/estacaoTipoParametroController';
+
+const routes = Router();
+
+routes.post('/', estacaoTipoParametroController.save);       // Criar relação
+routes.get('/', estacaoTipoParametroController.findAll);     // Listar todas as relações
+routes.get('/:pk', estacaoTipoParametroController.findById); // Buscar relação por ID
+routes.get('/estacao/:estacao_pk', estacaoTipoParametroController.findByEstacao); // Buscar relações por estação
+routes.get('/tipo-parametro/:tipo_parametro_pk', estacaoTipoParametroController.findByTipoParametro); // Buscar relações por tipo de parâmetro
+routes.put('/:pk', estacaoTipoParametroController.update);   // Atualizar relação
+routes.delete('/:pk', estacaoTipoParametroController.delete); // Deletar relação por ID
+routes.delete('/estacao/:estacao_pk/tipo-parametro/:tipo_parametro_pk', estacaoTipoParametroController.deleteByEstacaoAndTipoParametro); // Deletar relação específica
+
+export default routes;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,8 +1,14 @@
 import { Router } from 'express'
 import estacaoRoutes from './estacaoRoutes'
+import estacaoTipoParametro from './estacaoTipoParametroRoutes'
+import tipoParametro from './tipoParametroRoutes'
+import valorcapturado from './valorCapturadoRoutes'
 
 const router = Router();
 
 router.use('/estacao', estacaoRoutes)
+router.use('/estacao-tipo-parametro', estacaoTipoParametro)
+router.use('/tipo-parametro', tipoParametro)
+router.use('/valor-capturado', valorcapturado)
 
 export default router;

--- a/src/routes/tipoParametroRoutes.ts
+++ b/src/routes/tipoParametroRoutes.ts
@@ -1,0 +1,12 @@
+import { Router } from 'express';
+import { tipoParametroController } from '../controllers/tipoParametroController';
+
+const routes = Router();
+
+routes.post('/', tipoParametroController.save);       // Criar
+routes.get('/', tipoParametroController.findAll);     // Listar
+routes.get('/:pk', tipoParametroController.findById);     // Listar
+routes.put('/:pk', tipoParametroController.update);   // Atualizar
+routes.delete('/:pk', tipoParametroController.delete); // Deletar
+
+export default routes;

--- a/src/routes/valorCapturadoRoutes.ts
+++ b/src/routes/valorCapturadoRoutes.ts
@@ -1,0 +1,15 @@
+import { Router } from 'express';
+import { valorCapturadoController } from '../controllers/valorCapturadoController';
+
+const routes = Router();
+
+routes.post('/', valorCapturadoController.save);       // Criar valor capturado
+routes.get('/', valorCapturadoController.findAll);     // Listar todos os valores
+routes.get('/:pk', valorCapturadoController.findById); // Buscar valor por ID
+routes.get('/parametro/:parametro_pk', valorCapturadoController.findByParametro); // Buscar valores por parâmetro
+routes.get('/estacao/:estacao_id', valorCapturadoController.findByEstacao); // Buscar valores por estação
+routes.get('/filtros/periodo', valorCapturadoController.findByDateRange); // Buscar valores por período e filtros
+routes.put('/:pk', valorCapturadoController.update);   // Atualizar valor
+routes.delete('/:pk', valorCapturadoController.delete); // Deletar valor
+
+export default routes;


### PR DESCRIPTION
# CRUD de parâmetros (backend) 

## O que foi feito:
- Desenvolvido CRUD de tipo_parametros, valor_capturado e parametros

## Como testar:
1. garantir que tem banco de dados 'atmos' localmente
2. configurar variáveis no arquivo .env
3. instalar dependências:
```
npm install
```
4. executar:
```
npm start
```
    
## Checklist 
- [ ] CRUD tipo_parametros
- [ ] CRUD parametros
- [ ] CRUD valor_capturado
