### PR TITLE
AT-27 feat: adicionar crud de tipo alerta

### DIFF
--- a/src/config/connection.ts
+++ b/src/config/connection.ts
@@ -5,6 +5,8 @@ import TipoParametro from '../models/TipoParametro';
 import EstacaoTipoParametro from '../models/EstacaoTipoParametro';
 import ValorCapturado from '../models/ValorCapturado';
 import Usuario from '../models/Usuario';
+import TipoAlertaParametro from '../models/TipoAlertaParametro';
+import TipoAlerta from '../models/TipoAlerta';
 
 dotenv.config();
 
@@ -15,7 +17,7 @@ const sequelize = new Sequelize({
   host: process.env.DB_HOST, // colocar domínio
   port: parseInt(process.env.DB_PORT), // colocar porta
   dialect: 'postgres', // colocar o banco de dados utilizado
-  models: [Estacao, TipoParametro, EstacaoTipoParametro, ValorCapturado, Usuario],  // Adicionar os modelos a serem trabalhados aqui
+  models: [Estacao, TipoParametro, EstacaoTipoParametro, ValorCapturado, Usuario, TipoAlerta, TipoAlertaParametro],  // Adicionar os modelos a serem trabalhados aqui
 });
 
 export default sequelize;

--- a/src/controllers/tipoAlertaController.ts
+++ b/src/controllers/tipoAlertaController.ts
@@ -1,0 +1,76 @@
+import { Request, Response } from 'express'
+import TipoAlerta from '../models/TipoAlerta'
+
+export const tipoAlertaController = {
+    save: async (req: Request, res: Response) => {
+        try {
+            const novoRegistro = await TipoAlerta.create(req.body)
+            return res.status(201).json(novoRegistro)
+        } catch (error) {
+            return res.status(400).json({ error: 'Erro ao salvar tipo de alerta', detalhes: error.message })
+        }
+    },
+
+    findAll: async (req: Request, res: Response) => {
+        try {
+            const registros = await TipoAlerta.findAll()
+            if(!registros.length){
+                return res.status(404).json({ error: 'Registros não encontrados' })
+            }
+            return res.status(200).json(registros)
+        } catch (error) {
+            return res.status(500).json({error: 'Erro ao buscar registros', detalhes: error.message})
+        }
+    },
+
+    findById: async (req: Request, res: Response) => {
+        try {
+            const { pk } = req.params
+            const registro = await TipoAlerta.findByPk(pk)
+            if(registro) {
+                return res.status(200).json(registro)
+            }
+            return res.status(404).json({ error: 'Registro não encontrado' })
+        } catch (error) {
+            return res.status(500).json({error: 'Erro ao buscar registro', detalhes: error.message})
+        }
+    },
+
+    update: async (req: Request, res: Response) => {
+        try {
+        const { pk } = req.params;
+
+        const registro = await TipoAlerta.findByPk(pk)
+        if(!registro){
+            return res.status(404).json({ error: 'Registro não encontrado' })
+        }
+
+        const atualizado = await TipoAlerta.update(req.body, { where: { pk } });
+
+        if (atualizado) {
+            const registro = await TipoAlerta.findByPk(pk);
+            return res.json(registro);
+        }
+
+        } catch (error: any) {
+        return res.status(400).json({ error: 'Erro ao atualizar registro', detalhes: error.message });
+        }
+    },
+
+    delete: async (req: Request, res: Response) => {
+        try {
+        const { pk } = req.params;
+
+        const deletado = await TipoAlerta.destroy({ where: { pk } });
+
+        if (deletado) {
+            return res.status(204).send();
+        }
+
+        return res.status(404).json({ error: 'Registro não encontrado' });
+        } catch (error: any) {
+        return res.status(400).json({ error: 'Erro ao deletar registro', detalhes: error.message });
+        }
+    }
+}
+

--- a/src/controllers/tipoAlertaParametroController.ts
+++ b/src/controllers/tipoAlertaParametroController.ts
@@ -1,0 +1,156 @@
+import { Request, Response } from 'express'
+import TipoAlertaParametro from '../models/TipoAlertaParametro'
+import TipoAlerta from '../models/TipoAlerta'
+import TipoParametro from '../models/TipoParametro'
+
+export const tipoAlertaParametroController = {
+    save: async (req: Request, res: Response) => {
+        try {
+            const novoRegistro = await TipoAlertaParametro.create(req.body)
+            return res.status(201).json(novoRegistro)
+        } catch (error) {
+            return res.status(400).json({ error: 'Erro ao salvar relacionamento tipo alerta parâmetro', detalhes: error.message })
+        }
+    },
+
+    findAll: async (req: Request, res: Response) => {
+        try {
+            const registros = await TipoAlertaParametro.findAll({
+                include: [
+                    {
+                        model: TipoAlerta,
+                        as: 'tipoAlerta'
+                    },
+                    {
+                        model: TipoParametro,
+                        as: 'tipoParametro'
+                    }
+                ]
+            })
+            if(!registros.length){
+                return res.status(404).json({ error: 'Registros não encontrados' })
+            }
+            return res.status(200).json(registros)
+        } catch (error) {
+            return res.status(500).json({error: 'Erro ao buscar registros', detalhes: error.message})
+        }
+    },
+
+    findByTipoAlerta: async (req: Request, res: Response) => {
+        try {
+            const { tipoAlertaPk } = req.params
+            const registros = await TipoAlertaParametro.findAll({
+                where: { Tipo_Alerta_pk: tipoAlertaPk },
+                include: [
+                    {
+                        model: TipoAlerta,
+                        as: 'tipoAlerta'
+                    },
+                    {
+                        model: TipoParametro,
+                        as: 'tipoParametro'
+                    }
+                ]
+            })
+            if(!registros.length){
+                return res.status(404).json({ error: 'Registros não encontrados' })
+            }
+            return res.status(200).json(registros)
+        } catch (error) {
+            return res.status(500).json({error: 'Erro ao buscar registros', detalhes: error.message})
+        }
+    },
+
+    findByTipoParametro: async (req: Request, res: Response) => {
+        try {
+            const { tipoParametroPk } = req.params
+            const registros = await TipoAlertaParametro.findAll({
+                where: { Tipo_parametro_p: tipoParametroPk },
+                include: [
+                    {
+                        model: TipoAlerta,
+                        as: 'tipoAlerta'
+                    },
+                    {
+                        model: TipoParametro,
+                        as: 'tipoParametro'
+                    }
+                ]
+            })
+            if(!registros.length){
+                return res.status(404).json({ error: 'Registros não encontrados' })
+            }
+            return res.status(200).json(registros)
+        } catch (error) {
+            return res.status(500).json({error: 'Erro ao buscar registros', detalhes: error.message})
+        }
+    },
+
+    update: async (req: Request, res: Response) => {
+        try {
+        const { tipoAlertaPk, tipoParametroPk } = req.params;
+
+        const registro = await TipoAlertaParametro.findOne({
+            where: { 
+                Tipo_Alerta_pk: tipoAlertaPk,
+                Tipo_parametro_p: tipoParametroPk
+            }
+        })
+        if(!registro){
+            return res.status(404).json({ error: 'Registro não encontrado' })
+        }
+
+        const atualizado = await TipoAlertaParametro.update(req.body, { 
+            where: { 
+                Tipo_Alerta_pk: tipoAlertaPk,
+                Tipo_parametro_p: tipoParametroPk
+            } 
+        });
+
+        if (atualizado) {
+            const registro = await TipoAlertaParametro.findOne({
+                where: { 
+                    Tipo_Alerta_pk: tipoAlertaPk,
+                    Tipo_parametro_p: tipoParametroPk
+                },
+                include: [
+                    {
+                        model: TipoAlerta,
+                        as: 'tipoAlerta'
+                    },
+                    {
+                        model: TipoParametro,
+                        as: 'tipoParametro'
+                    }
+                ]
+            });
+            return res.json(registro);
+        }
+
+        } catch (error: any) {
+        return res.status(400).json({ error: 'Erro ao atualizar registro', detalhes: error.message });
+        }
+    },
+
+    delete: async (req: Request, res: Response) => {
+        try {
+        const { tipoAlertaPk, tipoParametroPk } = req.params;
+
+        const deletado = await TipoAlertaParametro.destroy({ 
+            where: { 
+                Tipo_Alerta_pk: tipoAlertaPk,
+                Tipo_parametro_p: tipoParametroPk
+            } 
+        });
+
+        if (deletado) {
+            return res.status(204).send();
+        }
+
+        return res.status(404).json({ error: 'Registro não encontrado' });
+        } catch (error: any) {
+        return res.status(400).json({ error: 'Erro ao deletar registro', detalhes: error.message });
+        }
+    }
+}
+

--- a/src/interfaces/swagger/swagger.ts
+++ b/src/interfaces/swagger/swagger.ts
@@ -5,6 +5,8 @@ import { tipoParametroSwagger } from './tipoParametroSwagger'
 import { estacaoTipoParametroSwagger } from './estacaoTipoParametroSwagger'
 import { valorCapturadoSwagger } from './valorCapturadoSwagger'
 import { usuarioSwagger } from "./usuarioSwagger";
+import { tipoAlertaSwagger } from './tipoAlertaSwagger'
+import { tipoAlertaParametroSwagger } from './tipoAlertaParametroSwagger'
 
 export function registerSwagger(app: Express): void {
   const openapi = {
@@ -20,7 +22,9 @@ export function registerSwagger(app: Express): void {
       ...estacaoSwagger,
       ...tipoParametroSwagger,
       ...estacaoTipoParametroSwagger,
-      ...valorCapturadoSwagger
+      ...valorCapturadoSwagger,
+      ...tipoAlertaSwagger,
+      ...tipoAlertaParametroSwagger
     },
   } as const
 

--- a/src/interfaces/swagger/tipoAlertaParametroSwagger.ts
+++ b/src/interfaces/swagger/tipoAlertaParametroSwagger.ts
@@ -1,0 +1,222 @@
+export const tipoAlertaParametroSwagger = {
+  "/tipo-alerta-parametro": {
+    post: {
+      summary: "Criar um novo relacionamento entre tipo de alerta e parâmetro",
+      requestBody: {
+        description: "Dados do relacionamento para criar",
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              properties: {
+                Tipo_parametro_p: { type: "integer", description: "ID do tipo de parâmetro" },
+                Tipo_Alerta_pk: { type: "integer", description: "ID do tipo de alerta" },
+              },
+              required: ["Tipo_parametro_p", "Tipo_Alerta_pk"],
+            },
+          },
+        },
+      },
+      responses: {
+        "201": {
+          description: "Relacionamento criado com sucesso",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  Tipo_parametro_p: { type: "integer" },
+                  Tipo_Alerta_pk: { type: "integer" },
+                },
+              },
+            },
+          },
+        },
+        "400": {
+          description: "Erro de validação",
+        },
+      },
+    },
+    get: {
+      summary: "Listar todos os relacionamentos entre tipos de alertas e parâmetros",
+      responses: {
+        "200": {
+          description: "Lista de relacionamentos",
+          content: {
+            "application/json": {
+              schema: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    Tipo_parametro_p: { type: "integer" },
+                    Tipo_Alerta_pk: { type: "integer" },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "404": {
+          description: "Nenhum relacionamento encontrado",
+        },
+      },
+    },
+  },
+  "/tipo-alerta-parametro/tipo-alerta/{tipoAlertaPk}": {
+    get: {
+      summary: "Listar parâmetros relacionados a um tipo de alerta",
+      parameters: [
+        {
+          in: "path",
+          name: "tipoAlertaPk",
+          required: true,
+          schema: { type: "integer" },
+          description: "ID do tipo de alerta",
+        },
+      ],
+      responses: {
+        "200": {
+          description: "Lista de parâmetros relacionados ao tipo de alerta",
+          content: {
+            "application/json": {
+              schema: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    Tipo_parametro_p: { type: "integer" },
+                    Tipo_Alerta_pk: { type: "integer" },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "404": {
+          description: "Nenhum parâmetro relacionado encontrado",
+        },
+      },
+    },
+  },
+  "/tipo-alerta-parametro/tipo-parametro/{tipoParametroPk}": {
+    get: {
+      summary: "Listar tipos de alertas relacionados a um tipo de parâmetro",
+      parameters: [
+        {
+          in: "path",
+          name: "tipoParametroPk",
+          required: true,
+          schema: { type: "integer" },
+          description: "ID do tipo de parâmetro",
+        },
+      ],
+      responses: {
+        "200": {
+          description: "Lista de tipos de alertas relacionados ao parâmetro",
+          content: {
+            "application/json": {
+              schema: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    Tipo_parametro_p: { type: "integer" },
+                    Tipo_Alerta_pk: { type: "integer" },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "404": {
+          description: "Nenhum tipo de alerta relacionado encontrado",
+        },
+      },
+    },
+  },
+  "/tipo-alerta-parametro/{tipoAlertaPk}/{tipoParametroPk}": {
+    put: {
+      summary: "Atualizar um relacionamento entre tipo de alerta e parâmetro",
+      parameters: [
+        {
+          in: "path",
+          name: "tipoAlertaPk",
+          required: true,
+          schema: { type: "integer" },
+          description: "ID do tipo de alerta",
+        },
+        {
+          in: "path",
+          name: "tipoParametroPk",
+          required: true,
+          schema: { type: "integer" },
+          description: "ID do tipo de parâmetro",
+        },
+      ],
+      requestBody: {
+        description: "Dados do relacionamento para atualizar",
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              properties: {
+                Tipo_parametro_p: { type: "integer", description: "ID do tipo de parâmetro" },
+                Tipo_Alerta_pk: { type: "integer", description: "ID do tipo de alerta" },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        "200": {
+          description: "Relacionamento atualizado com sucesso",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  Tipo_parametro_p: { type: "integer" },
+                  Tipo_Alerta_pk: { type: "integer" },
+                },
+              },
+            },
+          },
+        },
+        "404": {
+          description: "Relacionamento não encontrado",
+        },
+      },
+    },
+    delete: {
+      summary: "Excluir um relacionamento entre tipo de alerta e parâmetro",
+      parameters: [
+        {
+          in: "path",
+          name: "tipoAlertaPk",
+          required: true,
+          schema: { type: "integer" },
+          description: "ID do tipo de alerta",
+        },
+        {
+          in: "path",
+          name: "tipoParametroPk",
+          required: true,
+          schema: { type: "integer" },
+          description: "ID do tipo de parâmetro",
+        },
+      ],
+      responses: {
+        "204": {
+          description: "Relacionamento deletado com sucesso",
+        },
+        "404": {
+          description: "Relacionamento não encontrado",
+        },
+      },
+    },
+  },
+};
+

--- a/src/interfaces/swagger/tipoAlertaSwagger.ts
+++ b/src/interfaces/swagger/tipoAlertaSwagger.ts
@@ -1,0 +1,194 @@
+export const tipoAlertaSwagger = {
+  "/tipo-alerta": {
+    post: {
+      summary: "Criar um novo tipo de alerta",
+      requestBody: {
+        description: "Dados do tipo de alerta para criar",
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              properties: {
+                tipo: { type: "string", nullable: true },
+                descricao: { type: "string", nullable: true },
+                publica: { type: "boolean", nullable: true },
+                tipo_alarme: { type: "integer", nullable: true },
+                p1: { type: "number", nullable: true },
+                p2: { type: "number", nullable: true },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        "201": {
+          description: "Tipo de alerta criado com sucesso",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  pk: { type: "integer" },
+                  tipo: { type: "string", nullable: true },
+                  descricao: { type: "string", nullable: true },
+                  publica: { type: "boolean", nullable: true },
+                  tipo_alarme: { type: "integer", nullable: true },
+                  p1: { type: "number", nullable: true },
+                  p2: { type: "number", nullable: true },
+                },
+              },
+            },
+          },
+        },
+        "400": {
+          description: "Erro de validação",
+        },
+      },
+    },
+    get: {
+      summary: "Listar todos os tipos de alertas",
+      responses: {
+        "200": {
+          description: "Lista de tipos de alertas",
+          content: {
+            "application/json": {
+              schema: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    pk: { type: "integer" },
+                    tipo: { type: "string", nullable: true },
+                    descricao: { type: "string", nullable: true },
+                    publica: { type: "boolean", nullable: true },
+                    tipo_alarme: { type: "integer", nullable: true },
+                    p1: { type: "number", nullable: true },
+                    p2: { type: "number", nullable: true },
+                  },
+                },
+              },
+            },
+          },
+        },
+        "404": {
+          description: "Nenhum tipo de alerta encontrado",
+        },
+      },
+    },
+  },
+  "/tipo-alerta/{pk}": {
+    get: {
+      summary: "Obter um tipo de alerta pelo ID",
+      parameters: [
+        {
+          in: "path",
+          name: "pk",
+          required: true,
+          schema: { type: "integer" },
+          description: "ID do tipo de alerta",
+        },
+      ],
+      responses: {
+        "200": {
+          description: "Tipo de alerta encontrado",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  pk: { type: "integer" },
+                  tipo: { type: "string", nullable: true },
+                  descricao: { type: "string", nullable: true },
+                  publica: { type: "boolean", nullable: true },
+                  tipo_alarme: { type: "integer", nullable: true },
+                  p1: { type: "number", nullable: true },
+                  p2: { type: "number", nullable: true },
+                },
+              },
+            },
+          },
+        },
+        "404": {
+          description: "Tipo de alerta não encontrado",
+        },
+      },
+    },
+    put: {
+      summary: "Atualizar um tipo de alerta",
+      parameters: [
+        {
+          in: "path",
+          name: "pk",
+          required: true,
+          schema: { type: "integer" },
+          description: "ID do tipo de alerta",
+        },
+      ],
+      requestBody: {
+        description: "Dados do tipo de alerta para atualizar",
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              properties: {
+                tipo: { type: "string", nullable: true },
+                descricao: { type: "string", nullable: true },
+                publica: { type: "boolean", nullable: true },
+                tipo_alarme: { type: "integer", nullable: true },
+                p1: { type: "number", nullable: true },
+                p2: { type: "number", nullable: true },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        "200": {
+          description: "Tipo de alerta atualizado com sucesso",
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  pk: { type: "integer" },
+                  tipo: { type: "string", nullable: true },
+                  descricao: { type: "string", nullable: true },
+                  publica: { type: "boolean", nullable: true },
+                  tipo_alarme: { type: "integer", nullable: true },
+                  p1: { type: "number", nullable: true },
+                  p2: { type: "number", nullable: true },
+                },
+              },
+            },
+          },
+        },
+        "404": {
+          description: "Tipo de alerta não encontrado",
+        },
+      },
+    },
+    delete: {
+      summary: "Excluir um tipo de alerta",
+      parameters: [
+        {
+          in: "path",
+          name: "pk",
+          required: true,
+          schema: { type: "integer" },
+          description: "ID do tipo de alerta",
+        },
+      ],
+      responses: {
+        "204": {
+          description: "Tipo de alerta deletado com sucesso",
+        },
+        "404": {
+          description: "Tipo de alerta não encontrado",
+        },
+      },
+    },
+  },
+};
+

--- a/src/models/TipoAlerta.ts
+++ b/src/models/TipoAlerta.ts
@@ -1,0 +1,57 @@
+import { Table, Column, Model, DataType, BelongsToMany } from 'sequelize-typescript';
+import TipoParametro from './TipoParametro';
+import TipoAlertaParametro from './TipoAlertaParametro';
+
+@Table({
+    tableName: 'tipo_alerta',
+    timestamps: false
+})
+export default class TipoAlerta extends Model {
+
+    @Column({
+        type: DataType.INTEGER,
+        primaryKey: true,
+        autoIncrement: true
+    })
+    pk!: number;
+
+    @Column({
+        type: DataType.STRING(255),
+        allowNull: true
+    })
+    tipo!: string | null;
+
+    @Column({
+        type: DataType.TEXT,
+        allowNull: true
+    })
+    descricao!: string | null;
+
+    @Column({
+        type: DataType.BOOLEAN,
+        allowNull: true
+    })
+    publica!: boolean | null;
+
+    @Column({
+        type: DataType.SMALLINT,
+        allowNull: true
+    })
+    tipo_alarme!: number | null;
+
+    @Column({
+        type: DataType.DECIMAL(8, 4),
+        allowNull: true
+    })
+    p1!: number | null;
+
+    @Column({
+        type: DataType.DECIMAL(8, 4),
+        allowNull: true
+    })
+    p2!: number | null;
+
+    @BelongsToMany(() => TipoParametro, () => TipoAlertaParametro, 'Tipo_Alerta_pk', 'Tipo_parametro_p')
+    tipoParametros!: TipoParametro[];
+}
+

--- a/src/models/TipoAlertaParametro.ts
+++ b/src/models/TipoAlertaParametro.ts
@@ -1,0 +1,33 @@
+import { Table, Column, Model, DataType, BelongsTo, ForeignKey } from 'sequelize-typescript';
+import TipoAlerta from './TipoAlerta';
+import TipoParametro from './TipoParametro';
+
+@Table({
+    tableName: 'tipo_alerta_parametro',
+    timestamps: false
+})
+export default class TipoAlertaParametro extends Model {
+
+    @ForeignKey(() => TipoParametro)
+    @Column({
+        type: DataType.INTEGER,
+        allowNull: false,
+        field: 'Tipo_parametro_p'
+    })
+    Tipo_parametro_p!: number;
+
+    @ForeignKey(() => TipoAlerta)
+    @Column({
+        type: DataType.INTEGER,
+        allowNull: false,
+        field: 'Tipo_Alerta_pk'
+    })
+    Tipo_Alerta_pk!: number;
+
+    @BelongsTo(() => TipoParametro)
+    tipoParametro!: TipoParametro;
+
+    @BelongsTo(() => TipoAlerta)
+    tipoAlerta!: TipoAlerta;
+}
+

--- a/src/models/TipoParametro.ts
+++ b/src/models/TipoParametro.ts
@@ -1,6 +1,8 @@
 import { Table, Column, Model, DataType, BelongsToMany } from 'sequelize-typescript';
 import Estacao from './Estacao';
 import EstacaoTipoParametro from './EstacaoTipoParametro';
+import TipoAlerta from './TipoAlerta';
+import TipoAlertaParametro from './TipoAlertaParametro';
 
 @Table({
     tableName: 'tipo_parametro',
@@ -65,4 +67,7 @@ export default class TipoParametro extends Model {
 
     @BelongsToMany(() => Estacao, () => EstacaoTipoParametro, 'tipo_parametro_pk', 'estacao_est_pk')
     estacoes!: Estacao[];
+
+    @BelongsToMany(() => TipoAlerta, () => TipoAlertaParametro, 'Tipo_parametro_p', 'Tipo_Alerta_pk')
+    tipoAlertas!: TipoAlerta[];
 }

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -4,6 +4,8 @@ import estacaoTipoParametro from './estacaoTipoParametroRoutes'
 import tipoParametro from './tipoParametroRoutes'
 import valorcapturado from './valorCapturadoRoutes'
 import usuarioRoutes from './usuarioRoutes'
+import tipoAlertaRoutes from './tipoAlertaRoutes'
+import tipoAlertaParametroRoutes from './tipoAlertaParametroRoutes'
 
 const router = Router();
 
@@ -12,5 +14,7 @@ router.use('/estacao', estacaoRoutes)
 router.use('/estacao-tipo-parametro', estacaoTipoParametro)
 router.use('/tipo-parametro', tipoParametro)
 router.use('/valor-capturado', valorcapturado)
+router.use('/tipo-alerta', tipoAlertaRoutes)
+router.use('/tipo-alerta-parametro', tipoAlertaParametroRoutes)
 
 export default router;

--- a/src/routes/tipoAlertaParametroRoutes.ts
+++ b/src/routes/tipoAlertaParametroRoutes.ts
@@ -1,0 +1,14 @@
+import { Router } from 'express';
+import { tipoAlertaParametroController } from '../controllers/tipoAlertaParametroController';
+
+const routes = Router();
+
+routes.post('/', tipoAlertaParametroController.save);       // Criar relacionamento
+routes.get('/', tipoAlertaParametroController.findAll);     // Listar todos os relacionamentos
+routes.get('/tipo-alerta/:tipoAlertaPk', tipoAlertaParametroController.findByTipoAlerta);     // Listar por tipo de alerta
+routes.get('/tipo-parametro/:tipoParametroPk', tipoAlertaParametroController.findByTipoParametro);     // Listar por tipo de parâmetro
+routes.put('/:tipoAlertaPk/:tipoParametroPk', tipoAlertaParametroController.update);   // Atualizar relacionamento
+routes.delete('/:tipoAlertaPk/:tipoParametroPk', tipoAlertaParametroController.delete); // Deletar relacionamento
+
+export default routes;
+

--- a/src/routes/tipoAlertaRoutes.ts
+++ b/src/routes/tipoAlertaRoutes.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+import { tipoAlertaController } from '../controllers/tipoAlertaController';
+
+const routes = Router();
+
+routes.post('/', tipoAlertaController.save);       // Criar
+routes.get('/', tipoAlertaController.findAll);     // Listar
+routes.get('/:pk', tipoAlertaController.findById);     // Listar por ID
+routes.put('/:pk', tipoAlertaController.update);   // Atualizar
+routes.delete('/:pk', tipoAlertaController.delete); // Deletar
+
+export default routes;
+


### PR DESCRIPTION
# AT-27 CRUD de tipos de alerta

## O que foi feito:
- CRUD de tipo alerta
- CRUD de tipo_alerta_parametro

## Como testar:
1. Certificar de que tenha o banco de dados criado e esteja configurado em .env
2. Instalar dependências:
```
npm install
```
3. Executar
```
npm run start
```
4. Testar rotas em 'localhost:PORT':

POST /tipo-alerta:
```json
{
  "tipo": "Temperatura Alta",
  "descricao": "Alerta disparado quando a temperatura excede o limite máximo configurado",
  "publica": true,
  "tipo_alarme": 1,
  "p1": 35.5,
  "p2": 40.0
}
```
POST /tipo-parametro (para testar o relacionamento):
```json
{
  "json_id": "TEMP_001",
  "nome": "Temperatura Ambiente",
  "tipo": "float",
  "offset": 0.0,
  "fator": 1.0,
  "polinomio": null,
  "unidade": "°C",
  "alarme": 35.0
}
```
POST /tipo-alerta-parametro (para relacionar os dois itens criados, garantir que seja id dos itens recém criados):    
```json
{
  "Tipo_parametro_p": 1,
  "Tipo_Alerta_pk": 1
}
```
## Checklist 
- [ ] Adicionado novas dependências

